### PR TITLE
feat: Add smv_replacement_refs_suffix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@
 Changelog
 =========
 
+Version 0.3
+===========
+
+Version 0.3.0 (2022-04-12)
+--------------------------
+
+* Add ``smv_refs_override_suffix`` configuration option.
+
 Version 0.2
 ===========
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,8 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.4"
-version = "0.2"
+release = "0.3.0"
+version = "0.3"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 
 html_theme = "alabaster"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,9 @@ This is what the default configuration looks like:
     # Determines whether remote or local git branches/tags are preferred if their output dirs conflict
     smv_prefer_remote_refs = False
 
+    # Suffix for branches and tags to use as an override for refs
+    smv_refs_override_suffix = r'-docs'
+
 You can override all of these values inside your :file:`conf.py`.
 
 .. note::
@@ -56,6 +59,19 @@ Here are some examples:
 .. note::
 
     To list values to match, you can use ``git branch``, ``git tag`` and ``git remote``.
+
+
+Overriding the Source for a Tag or Branch
+=========================================
+
+If you specify ``smv_refs_override_suffix`` with a value like ``-docs`` and you
+have a tag with a name like ``v0.1.0`` and branch with a name like ``v0.1.0-docs``,
+you can override and replace the branch data that ``sphinx-multiversion`` copies
+into the temporary directory when it builds the ref.
+
+As long as the original ref like ``v0.1.0`` passes the branch and tag whitelist
+checks, then ``sphinx-multiversion`` makes a copy of the repository from the
+``v0.1.0-docs`` ref when it performs the build rather than ``v0.1.0``.
 
 
 Release Pattern

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.2.4",
+    version="0.3.0",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/__init__.py
+++ b/sphinx_multiversion/__init__.py
@@ -2,7 +2,7 @@
 from .sphinx import setup
 from .main import main
 
-__version__ = "0.2.4"
+__version__ = "0.3.0"
 
 __all__ = [
     "setup",

--- a/sphinx_multiversion/git.py
+++ b/sphinx_multiversion/git.py
@@ -20,6 +20,8 @@ GitRef = collections.namedtuple(
     ],
 )
 
+level = logging.DEBUG if os.environ["DEBUG"] else logging.INFO
+logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
@@ -69,12 +71,12 @@ def get_all_refs(gitroot):
         yield GitRef(name, commit, source, is_remote, refname, creatordate)
 
 
-def get_refs(
-    gitroot, tag_whitelist, branch_whitelist, remote_whitelist, files=()
-):
+def get_refs(gitroot, config, files=()):
     for ref in get_all_refs(gitroot):
         if ref.source == "tags":
-            if tag_whitelist is None or not re.match(tag_whitelist, ref.name):
+            if config.smv_tag_whitelist is None or not re.match(
+                config.smv_tag_whitelist, ref.name
+            ):
                 logger.debug(
                     "Skipping '%s' because tag '%s' doesn't match the "
                     "whitelist pattern",
@@ -83,8 +85,8 @@ def get_refs(
                 )
                 continue
         elif ref.source == "heads":
-            if branch_whitelist is None or not re.match(
-                branch_whitelist, ref.name
+            if config.smv_branch_whitelist is None or not re.match(
+                config.smv_branch_whitelist, ref.name
             ):
                 logger.debug(
                     "Skipping '%s' because branch '%s' doesn't match the "
@@ -93,9 +95,9 @@ def get_refs(
                     ref.name,
                 )
                 continue
-        elif ref.is_remote and remote_whitelist is not None:
+        elif ref.is_remote and config.smv_remote_whitelist is not None:
             remote_name = ref.source.partition("/")[2]
-            if not re.match(remote_whitelist, remote_name):
+            if not re.match(config.smv_remote_whitelist, remote_name):
                 logger.debug(
                     "Skipping '%s' because remote '%s' doesn't match the "
                     "whitelist pattern",
@@ -103,8 +105,8 @@ def get_refs(
                     remote_name,
                 )
                 continue
-            if branch_whitelist is None or not re.match(
-                branch_whitelist, ref.name
+            if config.smv_branch_whitelist is None or not re.match(
+                config.smv_branch_whitelist, ref.name
             ):
                 logger.debug(
                     "Skipping '%s' because branch '%s' doesn't match the "
@@ -119,6 +121,37 @@ def get_refs(
             )
             continue
 
+        # The ref exists and meets list checks. Check for an override ref.
+        if "" != config.smv_refs_override_suffix:
+            candidate = "{}{}".format(
+                ref.name, config.smv_refs_override_suffix
+            )
+            cmd = ["git", "show-ref", candidate]
+            proc = subprocess.run(cmd, cwd=gitroot, capture_output=True)
+            if 0 == proc.returncode:
+                override = proc.stdout.decode().split()[0]
+                logger.info(
+                    "Overriding the ref from {}:::{}".format(
+                        ref.refname, ref.commit
+                    )
+                )
+                logger.info("   ...to {}:::{}.".format(candidate, override))
+
+                cmd = [
+                    "git",
+                    "branch",
+                    candidate,
+                    "--track",
+                    "origin/{}".format(candidate),
+                ]
+                proc = subprocess.run(cmd, cwd=gitroot, capture_output=True)
+                if 0 != proc.returncode:
+                    logger.info(
+                        "Failed to create a local tracking branch for the override branch"
+                    )
+                ref = ref._replace(refname=candidate)
+                ref = ref._replace(commit=override)
+
         missing_files = [
             filename
             for filename in files
@@ -132,6 +165,8 @@ def get_refs(
                 missing_files,
             )
             continue
+
+        logger.debug("Planning to build '%s'", ref.refname)
 
         yield ref
 

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -67,6 +67,7 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
                 str,
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
+            current_config.add("smv_refs_override_suffix", "", "html", str)
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -206,9 +207,7 @@ def main(argv=None):
     # Get git references
     gitrefs = git.get_refs(
         str(gitroot),
-        config.smv_tag_whitelist,
-        config.smv_branch_whitelist,
-        config.smv_remote_whitelist,
+        config,
         files=(sourcedir, conffile),
     )
 

--- a/sphinx_multiversion/sphinx.py
+++ b/sphinx_multiversion/sphinx.py
@@ -210,6 +210,7 @@ def setup(app):
     app.add_config_value(
         "smv_outputdir_format", DEFAULT_OUTPUTDIR_FORMAT, "html"
     )
+    app.add_config_value("smv_refs_override_suffix", "", "html")
     app.connect("config-inited", config_inited)
 
     return {


### PR DESCRIPTION
Add `smv_refs_override_suffix` to your `conf.py`
with a value like `-docs` and if a branch or tag would
normally build, then SMV checks for a ref like
`/refs/heads/{the-good-ref}-docs` and if the ref exists,
SMV gets the archive of the repo from the override ref
when it builds the documentation.